### PR TITLE
Removed control chars and added support for input fields to display the password

### DIFF
--- a/pGenerator.jquery.js
+++ b/pGenerator.jquery.js
@@ -114,7 +114,7 @@
                 if($(settings.displayElement).is("input")) {
                     $(settings.displayElement).val(passwordString);
                 } else {
-                    $settings.displayElement).text(passwordString);
+                    $(settings.displayElement).text(passwordString);
                 }
 			}
 


### PR DESCRIPTION
- Removed control chars 28  + 29, these chars caused invalid passwords because the String.fromCharCode returned an empty string for it.
- Added support for input fields to display the generated password.
