### PR TITLE
Update pGenerator.jquery.js

### DIFF
--- a/pGenerator.jquery.js
+++ b/pGenerator.jquery.js
@@ -135,7 +135,13 @@
             password = shuffle(password).join('');
 
             if(settings.passwordElement !== null) {
-                $(settings.passwordElement).val(password);
+                 if (typeof settings.passwordElement === 'string') {
+                    $(settings.passwordElement).val(password);
+                }else if (Array.isArray(settings.passwordElement)){
+                    settings.passwordElement.forEach(function (item) {
+                        $(item).val(password);
+                    });
+                }
             }
 
             if(settings.displayElement !== null) {


### PR DESCRIPTION
  There is a situation where I need to set values for another password input(confirm the password), but currently only support single `passwordElement`, I would like to make `passwordElement` support Array so can set value for multiple password inputs;

Examples
```javascripts
$('#password-generator-button').pGenerator({
    'bind': 'click',
    'passwordElement': ['#password-input','#confirm_password'],
    'displayElement': '#display-password',
    'passwordLength': 16,
    'uppercase': true,
    'lowercase': true,
    'numbers':   true,
    'specialChars': true,
    'additionalSpecialChars': [],
    'onPasswordGenerated': function(generatedPassword) { }
});
```